### PR TITLE
feat: Add custom icon support

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,8 +31,9 @@ platforms: {
 	tizen: {
 		widget: '/path/to/config.xml',
 		tizenToolsDir: '/path/to/tizen-studio/tools/ide/bin',
-		securityProfile: 'security profile name'
-		sdbDir: '/path/to/tizen-studio/tools/'
+		securityProfile: 'security profile name',
+		sdbDir: '/path/to/tizen-studio/tools/',
+		iconPath: '/path/to/custom/icon.png'
 	}
 }
 ```

--- a/index.js
+++ b/index.js
@@ -177,10 +177,13 @@ class Tizen extends AbstractPlatform {
 	async pack(app, distDir) {
 		const config = app.getConfig();
 
-		const {securityProfile, tizenToolsDir} = config.platforms.tizen;
+		const {securityProfile, tizenToolsDir, iconPath} = config.platforms.tizen;
 
 		const configXml = await this._resolveConfigXmlPath(app);
 		await fse.copy(configXml, path.join(distDir, 'config.xml'));
+
+		const iconDest = await this._getIconDestination(app);
+		await fse.copy(iconPath, path.join(distDir, iconDest));
 
 		await activateProfile(tizenToolsDir, securityProfile);
 
@@ -226,6 +229,21 @@ class Tizen extends AbstractPlatform {
 
 		logger.silly(`Resolved app id "${appId}"`);
 		return appId;
+	}
+
+	/**
+	 * @param {Application} app
+	 * @return {Promise<string>}
+	 * @protected
+	 */
+	async _getIconDestination(app) {
+		const configXmlPath = await this._resolveConfigXmlPath(app);
+		const xml = await fse.readFile(configXmlPath, 'utf-8');
+		const data = await parseXml(xml);
+		const iconDest = data.widget['icon'][0].$.src;
+
+		logger.silly(`Resolved icon destination "${iconDest}"`);
+		return iconDest;
 	}
 
 	/**


### PR DESCRIPTION
I haven't found a way to add the icon in such a way that the `pack` or `build` actions automatically copy the icon file to the `dist` directory. This PR implements that feature.
The icon is copied from the given source path to the dist folder, taking into consideration the `icon` property in `config.xml`.

example `config.js`:
```js
// ...
	tizen: {
		widget: path.resolve(__dirname, 'tizen/config.xml'),
		tizenToolsDir: '/home/user/tizen-studio/tools/ide/bin',
		securityProfile: 'example_profile',
		sdbDir: '/home/user/tizen-studio/tools/',
		iconPath: path.resolve(__dirname, 'tizen/icon.png')
	}
// ...
```

I will be using my own fork of the platform abstraction layer until this PR gets approved and merged. I hope this makes sense :)